### PR TITLE
Integrate breakpad in Aker to Generate Minidump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ file(MAKE_DIRECTORY ${TEST_RESULTS_DIR})
 include_directories(${INCLUDE_DIR}
                     ${INCLUDE_DIR}/cimplog
                     ${INCLUDE_DIR}/msgpack
+                    ${INCLUDE_DIR}/libmpack
                     ${INCLUDE_DIR}/trower-base64
                     ${INCLUDE_DIR}/wrp-c
                     ${INCLUDE_DIR}/libparodus
@@ -51,6 +52,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall")
 #-------------------------------------------------------------------------------
 find_package (Threads)
 
+if (NOT BUILD_YOCTO)
+
 # curl external dependency
 #-------------------------------------------------------------------------------
 include(FindPkgConfig)
@@ -58,9 +61,6 @@ pkg_check_modules(CURL libcurl REQUIRED)
 include_directories(
   SYSTEM ${CURL_INCLUDE_DIRS}
 )
-
-
-if (NOT BUILD_YOCTO)
 
 # base64 external dependency
 #-------------------------------------------------------------------------------

--- a/src/main.c
+++ b/src/main.c
@@ -33,6 +33,10 @@
 #include "aker_mem.h"
 #include "aker_help.h"
 
+#ifdef INCLUDE_BREAKPAD
+#include "breakpad_wrapper.h"
+#endif
+
 /*----------------------------------------------------------------------------*/
 /*                                   Macros                                   */
 /*----------------------------------------------------------------------------*/
@@ -97,14 +101,19 @@ int main( int argc, char **argv)
     signal(SIGINT, sig_handler);
     signal(SIGUSR1, sig_handler);
     signal(SIGUSR2, sig_handler);
-    signal(SIGSEGV, sig_handler);
-    signal(SIGBUS, sig_handler);
     signal(SIGKILL, sig_handler);
-    signal(SIGFPE, sig_handler);
-    signal(SIGILL, sig_handler);
     signal(SIGQUIT, sig_handler);
     signal(SIGHUP, sig_handler);
     signal(SIGALRM, sig_handler);
+#ifdef INCLUDE_BREAKPAD
+    /* breakpad handles the signals SIGSEGV, SIGBUS, SIGFPE, and SIGILL */
+    breakpad_ExceptionHandler();
+#else
+    signal(SIGSEGV, sig_handler);
+    signal(SIGBUS, sig_handler); 
+    signal(SIGFPE, sig_handler);
+    signal(SIGILL, sig_handler);
+#endif  
     
     while( -1 != (item = getopt_long(argc, argv, option_string, options, &opt_index)) ) {
         switch( item ) {

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -32,6 +32,10 @@
 #include "time.h"
 #include "aker_mem.h"
 
+#ifdef INCLUDE_BREAKPAD
+#include "breakpad_wrapper.h"
+#endif
+
 
 /* Local Functions and file-scoped variables */
 static void sig_handler(int sig);
@@ -151,14 +155,19 @@ void *scheduler_thread(void *args)
     signal(SIGINT, sig_handler);
     signal(SIGUSR1, sig_handler);
     signal(SIGUSR2, sig_handler);
-    signal(SIGSEGV, sig_handler);
-    signal(SIGBUS, sig_handler);
     signal(SIGKILL, sig_handler);
-    signal(SIGFPE, sig_handler);
-    signal(SIGILL, sig_handler);
     signal(SIGQUIT, sig_handler);
     signal(SIGHUP, sig_handler);
-    signal(SIGALRM, sig_handler);    
+    signal(SIGALRM, sig_handler);
+#ifdef INCLUDE_BREAKPAD
+    /* breakpad handles the signals SIGSEGV, SIGBUS, SIGFPE, and SIGILL */
+    breakpad_ExceptionHandler();
+#else
+    signal(SIGSEGV, sig_handler);
+    signal(SIGBUS, sig_handler); 
+    signal(SIGFPE, sig_handler);
+    signal(SIGILL, sig_handler);
+#endif      
     
     firewall_cmd = (const char*) args;
 


### PR DESCRIPTION
Integrate Breakpad to generate minidump if Aker process is killed/crashed.