### PR TITLE
RDKB-37618: Fix for add Aker Assurance Metrics

### DIFF
--- a/src/aker_metrics.c
+++ b/src/aker_metrics.c
@@ -299,11 +299,11 @@ void aker_metric_set_tz_offset( long int val )
 /* See aker_metrics.h for details. */
 void aker_metrics_report_to_log()
 {
-	char str[128];
+	char str[512];
 
 	pthread_mutex_lock(&aker_metrics_mut);
     
-	snprintf(str, 128, "%d,%d,%d,%d,%ld,%d,%s,%+ld",
+	snprintf(str, 512, "%d,%d,%d,%d,%ld,%d,%s,%+ld",
 
 	                   g_metrics.device_block_count,
 	                   g_metrics.window_trans_count,


### PR DESCRIPTION
The previous change is working fine for hub4, but there is issue with other platforms.
I got the below error while triggering verification for other platforms.
aker_metrics.c:306:2: note: 'snprintf' output between 16 and 340 bytes into a destination of size 128
snprintf(str, 128, "%d,%d,%d,%d,%ld,%d,%s,%+ld",

So I changed the buffer back to 512 and checked the build in other platforms and is fine now.